### PR TITLE
Prevent site handlers from overriding Vim cursor controls

### DIFF
--- a/content.js
+++ b/content.js
@@ -174,6 +174,7 @@ document.addEventListener(
     if (event.key === "Escape") {
       event.preventDefault();
       event.stopPropagation();
+      event.stopImmediatePropagation();
       setMode("normal");
       return;
     }
@@ -181,6 +182,7 @@ document.addEventListener(
     if (mode === "normal") {
       event.preventDefault();
       event.stopPropagation();
+      event.stopImmediatePropagation();
       console.log(`[Vim-Extension] Normal mode command: ${event.key}`);
       const cursor = getCursorPosition(activeElement);
       const text = getText(activeElement);


### PR DESCRIPTION
## Summary
- block other event handlers when interpreting vim commands in normal mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c11e9c548832e91be38b250b40bf0