### PR TITLE
Add 'e' motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 
 - `w` - Jump forward to the start of the next word
 - `b` - Jump backward to the start of the previous word
+- `e` - Jump to the end of the current word
 
 **Editing Commands:**
 

--- a/src/content.js
+++ b/src/content.js
@@ -166,6 +166,7 @@
     moveDown,
     moveWordForward,
     moveWordBackward,
+    moveWordEnd,
     deleteText,
     deleteWord,
     changeWord
@@ -332,6 +333,7 @@
           'moveDown': () => moveDown(element),
           'moveWordForward': () => moveWordForward(element),
           'moveWordBackward': () => moveWordBackward(element),
+          'moveWordEnd': () => moveWordEnd(element),
           'deleteWord': () => deleteWord(element),
           'changeWord': () => changeWord(element)
         };

--- a/src/vim-motions.js
+++ b/src/vim-motions.js
@@ -247,6 +247,32 @@
     return true;
   };
 
+  const moveWordEnd = (element) => {
+    let pos = getCursorPosition(element);
+    const text = getText(element);
+
+    if (pos >= text.length) return false;
+
+    // Skip initial whitespace to mimic Vim's 'e'
+    while (pos < text.length && isWhitespace(text[pos])) pos++;
+
+    if (pos >= text.length) {
+      setCursorPosition(element, text.length);
+      return true;
+    }
+
+    const targetType = getCharType(text[pos]);
+
+    if (targetType === 'word') {
+      while (pos < text.length - 1 && isWordChar(text[pos + 1])) pos++;
+    } else if (targetType === 'punctuation') {
+      while (pos < text.length - 1 && isPunctuation(text[pos + 1])) pos++;
+    }
+
+    setCursorPosition(element, pos);
+    return true;
+  };
+
   // --- Text Modification Functions ---
 
   /**
@@ -472,6 +498,7 @@
     moveDown,
     moveWordForward,
     moveWordBackward,
+    moveWordEnd,
     deleteText,
     deleteWord,
     changeWord

--- a/src/vim-state-machine.js
+++ b/src/vim-state-machine.js
@@ -39,6 +39,7 @@
             'l': 'moveRight',
             'w': 'moveWordForward',
             'b': 'moveWordBackward',
+            'e': 'moveWordEnd',
             'arrowleft': 'moveLeft',
             'arrowdown': 'moveDown',
             'arrowup': 'moveUp',


### PR DESCRIPTION
## Summary
- implement `moveWordEnd` utility for moving to the end of a word
- expose new motion and bind it in the state machine
- wire the new action through content script
- document `e` word navigation in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68675080db58832ebd40f0bd70562420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the 'e' key to move the cursor to the end of the current word, mimicking Vim's 'e' motion.

* **Documentation**
  * Updated the README to document the new 'e' keybinding for word movement commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->